### PR TITLE
Added default constructor for CoreDbContext to allow Code First Migrations

### DIFF
--- a/Source/Core.EntityFramework/CoreDbContext.cs
+++ b/Source/Core.EntityFramework/CoreDbContext.cs
@@ -8,10 +8,11 @@ namespace Thinktecture.IdentityServer.Core.EntityFramework
         public CoreDbContext(string connectionString)
             : base(connectionString)
         {
+            Configuration.ProxyCreationEnabled = false;
         }
 
         public CoreDbContext()
-            : base("Thinktecture.IdentityServer.Core")
+            : this("Thinktecture.IdentityServer.Core")
         {
         }
 

--- a/Source/Core.EntityFramework/CoreDbContext.cs
+++ b/Source/Core.EntityFramework/CoreDbContext.cs
@@ -10,6 +10,11 @@ namespace Thinktecture.IdentityServer.Core.EntityFramework
         {
         }
 
+        public CoreDbContext()
+            : base("Thinktecture.IdentityServer.Core")
+        {
+        }
+
         public DbSet<Client> Clients { get; set; }
         public DbSet<Scope> Scopes { get; set; }
         public DbSet<Consent> Consents { get; set; }


### PR DESCRIPTION
#5 

After this change, I can succesfully create a code first migration configuration class. From this I can update my database using automatic migrations or, if needed, add code migrations. 

You might want to change the default connectionstring. I choose this one, but feel free to change it if you feel like it.

<!---
@huboard:{"order":766.25,"milestone_order":7,"custom_state":""}
-->
